### PR TITLE
Ignore invalid JSON bodies

### DIFF
--- a/integrationTests/fetch.test.ts
+++ b/integrationTests/fetch.test.ts
@@ -16,6 +16,7 @@ describe("integration: fetch", () => {
     HttpResponse.json({ success: false }, { status: 500 }),
   )
   const express = startExpress()
+  let port: number
   let testUrl: string
 
   beforeAll(async () => {
@@ -25,7 +26,8 @@ describe("integration: fetch", () => {
       environment: "test",
       reporting: { batchSize: 0 },
     })
-    const { port } = (await express).address() as AddressInfo
+    const addr = (await express).address() as AddressInfo
+    port = addr.port
     testUrl = `http://127.0.0.1:${port}/helloworld`
     msw.use(http.all(testUrl, () => passthrough()))
   })
@@ -227,6 +229,10 @@ describe("integration: fetch", () => {
       required: ["status"],
       type: "object",
     })
+  })
+
+  it("should ignore invalid json bodies", async () => {
+    await fetch(`http://127.0.0.1:${port}/invalid-json`)
   })
 
   it.todo("should should correctly report empty bodies")

--- a/integrationTests/server.ts
+++ b/integrationTests/server.ts
@@ -14,6 +14,12 @@ export const startExpress = async (): Promise<Server> => {
     res.json({ status: "OK" })
   })
 
+  app.get("/invalid-json", (_, res) => {
+    // Set our content type to application/json, but send a non-json body.
+    res.set("Content-Type", "application/json")
+    return res.end("not json")
+  })
+
   return new Promise((resolve) => {
     const server = app.listen(0, () => resolve(server))
   })


### PR DESCRIPTION
This should prevent request/response bodies that are reported as JSON (via `Content-Type`), but are not *actually* valid JSON from being parsed and throwing an error.