### PR TITLE
Ignore responses without request in fligth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appear.sh/introspector",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/intercept.ts
+++ b/src/intercept.ts
@@ -107,11 +107,12 @@ export async function intercept(
   interceptor.on("response", async ({ requestId, response }) => {
     const request = requests.get(requestId)
 
-    if (!request) {
-      throw new Error("Could not find corresponding request for response.")
-    } else {
-      requests.delete(requestId)
-    }
+    // If we don't have the request, we can't do anything.
+    // Usually this shouldn't happen, but in theory it could be in case of "response" event fired multiple times, in which case we can ignore it.
+    if (!request) return
+
+    // remove from requests in flight
+    requests.delete(requestId)
 
     if (!config.interception.filter(request, response, config)) {
       return


### PR DESCRIPTION
While this shouldn't usually happen we had a report of "response" event being fired multiple times. In such case we should be able to ignore the second one.