### PR TITLE
Improve forwarded requests

### DIFF
--- a/.changeset/bitter-tigers-invent.md
+++ b/.changeset/bitter-tigers-invent.md
@@ -1,0 +1,5 @@
+---
+"@appear.sh/introspector": patch
+---
+
+Support json parsing even if content-type header is not set

--- a/.changeset/twenty-ads-talk.md
+++ b/.changeset/twenty-ads-talk.md
@@ -1,0 +1,5 @@
+---
+"@appear.sh/introspector": patch
+---
+
+Improve support for proxied requests by respecting X-Forwarded-\* headers

--- a/packages/introspector/src/__snapshots__/process.test.ts.snap
+++ b/packages/introspector/src/__snapshots__/process.test.ts.snap
@@ -1,0 +1,77 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`process > body schema > should process a simple JSON request/response 1`] = `
+{
+  "direction": "incoming",
+  "request": {
+    "body": {
+      "contentMediaType": "application/json",
+      "contentSchema": {
+        "properties": {
+          "hello": {
+            "maxLength": 5,
+            "minLength": 5,
+            "type": "string",
+          },
+        },
+        "required": [
+          "hello",
+        ],
+        "type": "object",
+      },
+      "type": "string",
+    },
+    "headers": {
+      "content-type": {
+        "maxLength": 16,
+        "minLength": 16,
+        "type": "string",
+      },
+      "x-custom": {
+        "maxLength": 3,
+        "minLength": 3,
+        "type": "string",
+      },
+    },
+    "method": "POST",
+    "query": {
+      "foo": {
+        "maxLength": 3,
+        "minLength": 3,
+        "type": "string",
+      },
+    },
+    "uri": "http://localhost:3000/api/test",
+  },
+  "response": {
+    "body": {
+      "contentMediaType": "application/json",
+      "contentSchema": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+          },
+        },
+        "required": [
+          "ok",
+        ],
+        "type": "object",
+      },
+      "type": "string",
+    },
+    "headers": {
+      "content-type": {
+        "maxLength": 16,
+        "minLength": 16,
+        "type": "string",
+      },
+      "x-res": {
+        "maxLength": 3,
+        "minLength": 3,
+        "type": "string",
+      },
+    },
+    "statusCode": 200,
+  },
+}
+`;

--- a/packages/introspector/src/process.test.ts
+++ b/packages/introspector/src/process.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest"
+import { process } from "./process.js"
+
+describe("process", () => {
+  describe("request url normalization", () => {
+    it("should normalize localhost", async () => {
+      const req = new Request("http://127.0.0.1:3000/api/test?foo=bar")
+      const op = await process({
+        request: req,
+        response: new Response(),
+        direction: "incoming",
+      })
+      expect(op.request.uri).toBe("http://localhost:3000/api/test")
+    })
+
+    it("should remove unnecessary ports", async () => {
+      const req = new Request("https://localhost:443/api/test?foo=bar")
+      const op = await process({
+        request: req,
+        response: new Response(),
+        direction: "incoming",
+      })
+      expect(op.request.uri).toBe("https://localhost/api/test")
+    })
+
+    it("should normalize forwarded headers", async () => {
+      const req = new Request("http://127.0.0.1:3000/api/test?foo=bar", {
+        headers: {
+          "x-forwarded-host": "example.com",
+          "x-forwarded-proto": "https",
+          "x-forwarded-port": "443",
+        },
+      })
+      const op = await process({
+        request: req,
+        response: new Response(),
+        direction: "incoming",
+      })
+      expect(op.request.uri).toBe("https://example.com/api/test")
+    })
+  })
+
+  describe("body schema", () => {
+    it("should process a simple JSON request/response", async () => {
+      const req = new Request("http://127.0.0.1:3000/api/test?foo=bar", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-custom": "abc" },
+        body: JSON.stringify({ hello: "world" }),
+      })
+      const res = new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json", "x-res": "xyz" },
+      })
+
+      const op = await process({
+        request: req,
+        response: res,
+        direction: "incoming",
+      })
+
+      expect(op).toMatchSnapshot()
+      expect(op.direction).toBe("incoming")
+      expect(op.request.method).toBe("POST")
+      expect(op.request.uri).toBe("http://localhost:3000/api/test")
+      expect(op.request.headers).toHaveProperty("x-custom")
+      expect(op.request.query).toHaveProperty("foo")
+      expect(op.request.body).toMatchObject({
+        type: "string",
+        contentMediaType: "application/json",
+      })
+      expect(op.response.statusCode).toBe(200)
+      expect(op.response.headers).toHaveProperty("x-res")
+      expect(op.response.body).toMatchObject({
+        type: "string",
+        contentMediaType: "application/json",
+      })
+    })
+
+    it("should handle missing content-type and parse as JSON if possible", async () => {
+      const req = new Request("http://localhost/api/other", {
+        method: "POST",
+        body: JSON.stringify({ foo: 123 }),
+      })
+      const res = new Response("not json")
+      const op = await process({
+        request: req,
+        response: res,
+        direction: "outgoing",
+      })
+      expect(op.request.body).toMatchObject({
+        type: "string",
+        contentMediaType: "text/plain",
+      })
+      expect(op.response.body).toMatchObject({
+        type: "string",
+        contentMediaType: "text/plain",
+      })
+    })
+
+    it("should handle text response", async () => {
+      const req = new Request("http://localhost/api/text", { method: "GET" })
+      const res = new Response("hello", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      })
+      const op = await process({
+        request: req,
+        response: res,
+        direction: "incoming",
+      })
+      expect(op.response.body).toMatchObject({
+        type: "string",
+        contentMediaType: "text/plain",
+      })
+    })
+  })
+})


### PR DESCRIPTION
When headers are forwarded through proxy they may have changed url but set `X-Forwarded-*` headers with the original information. In our reports we are interested in the original url not the forwarded