### PR TITLE
Add next.js preset

### DIFF
--- a/.changeset/curvy-doodles-knock.md
+++ b/.changeset/curvy-doodles-knock.md
@@ -1,0 +1,11 @@
+---
+"@appear.sh/introspector": minor
+---
+
+Add Next.js instrumentation preset to allow for simpler setup with reduced noise.
+
+To use new preset simply update your import to point to new `/nextjs` entrypoint.
+
+```ts
+import { registerAppear } from "@appear.sh/instrumentation/nextjs"
+```

--- a/apps/nextjs-docker/appear.js
+++ b/apps/nextjs-docker/appear.js
@@ -1,4 +1,4 @@
-import { registerAppear } from "@appear.sh/introspector/node"
+import { registerAppear } from "@appear.sh/introspector/nextjs"
 
 registerAppear({
   apiKey: "test-key",

--- a/apps/nextjs-instrumentation-ts/instrumentation.ts
+++ b/apps/nextjs-instrumentation-ts/instrumentation.ts
@@ -1,7 +1,6 @@
-
 export const register = async () => {
   if (process.env.NEXT_RUNTIME === "nodejs") {
-    const { registerAppear } = await import("@appear.sh/introspector/node")
+    const { registerAppear } = await import("@appear.sh/introspector/nextjs")
     registerAppear({
       apiKey: "test-key",
       environment: "test",

--- a/apps/nextjs/appear.js
+++ b/apps/nextjs/appear.js
@@ -1,17 +1,8 @@
-import { registerAppear } from "@appear.sh/introspector/node"
-import { defaultInterceptFilter } from "@appear.sh/introspector"
+import { registerAppear } from "@appear.sh/introspector/nextjs"
 
 registerAppear({
   apiKey: "test-key",
   environment: "test",
   serviceName: "nextjs-test",
   reporting: { endpoint: process.env.COLLECTOR_URL },
-  interception: {
-    filter: (request, response, config) => {
-      return (
-        !request.url.includes("/_next/") &&
-        defaultInterceptFilter(request, response, config)
-      )
-    },
-  },
 })

--- a/packages/introspector/package.json
+++ b/packages/introspector/package.json
@@ -38,6 +38,16 @@
         "types": "./dist/node.d.ts",
         "default": "./dist/node.js"
       }
+    },
+    "./nextjs": {
+      "import": {
+        "import": "./dist/nextjs.mjs",
+        "types": "./dist/nextjs.d.mts"
+      },
+      "default": {
+        "types": "./dist/nextjs.d.ts",
+        "default": "./dist/nextjs.js"
+      }
     }
   },
   "scripts": {

--- a/packages/introspector/src/entrypoints/nextjs.ts
+++ b/packages/introspector/src/entrypoints/nextjs.ts
@@ -1,0 +1,36 @@
+import { ResolvedAppearConfig } from "../config.js"
+import { defaultInterceptFilter as baseInterceptFilter } from "../helpers.js"
+import { registerAppear as nodeRegisterAppear } from "./node.js"
+
+export {
+  AppearExporter,
+  AppearInstrumentation,
+  HttpInstrumentation,
+  UndiciInstrumentation,
+} from "./node.js"
+
+export const defaultInterceptFilter = (
+  request: Request,
+  response: Response,
+  config: ResolvedAppearConfig,
+): boolean => {
+  const [contentType, contentFormat] =
+    response.headers.get("content-type")?.toLowerCase()?.split("/") ?? []
+
+  return (
+    baseInterceptFilter(request, response, config) &&
+    !request.url.includes("/_next/") &&
+    contentType === "application" &&
+    !!contentFormat?.includes("json") // the contentFormat sometimes can include other attributes like "vnd.something-other+json" or json;charset=utf-8
+  )
+}
+
+export const registerAppear: typeof nodeRegisterAppear = (config) => {
+  return nodeRegisterAppear({
+    ...config,
+    interception: {
+      filter: defaultInterceptFilter,
+      ...config.interception,
+    },
+  })
+}

--- a/packages/introspector/src/entrypoints/node.ts
+++ b/packages/introspector/src/entrypoints/node.ts
@@ -1,5 +1,6 @@
-export { registerAppear } from "../otel/registerAppear.js"
+export { defaultInterceptFilter } from "../helpers.js"
 export { AppearExporter } from "../otel/AppearExporter.js"
 export { AppearInstrumentation } from "../otel/AppearInstrumentation.js"
 export { HttpInstrumentation } from "../otel/HttpInstrumentation.js"
+export { registerAppear } from "../otel/registerAppear.js"
 export { UndiciInstrumentation } from "../otel/UndiciInstrumentation.js"

--- a/packages/introspector/tsup.config.ts
+++ b/packages/introspector/tsup.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from "tsup"
 
 export default defineConfig({
-  entry: ["src/entrypoints/index.ts", "src/entrypoints/node.ts"],
+  entry: [
+    "src/entrypoints/index.ts",
+    "src/entrypoints/node.ts",
+    "src/entrypoints/nextjs.ts",
+  ],
   sourcemap: true,
   clean: true,
   format: ["esm", "cjs"],


### PR DESCRIPTION
Add Next.js instrumentation preset to allow for simpler setup with reduced noise.

To use new preset simply update your import to point to new `/nextjs` entrypoint.

```ts
import { registerAppear } from "@appear.sh/instrumentation/nextjs"
```